### PR TITLE
Require external dependencies

### DIFF
--- a/lib/grape-erb/formatter.rb
+++ b/lib/grape-erb/formatter.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+require 'tilt'
 
 module Grape
   module Erb


### PR DESCRIPTION
This is a tiny fix. This PR requires `tilt` properly so users no longer have to `require 'tilt'` from their own projects.
